### PR TITLE
Feature/chainlink triggers eng 1197

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/solmate"]
 	path = lib/solmate
 	url = https://github.com/transmissions11/solmate
+[submodule "lib/chainlink"]
+	path = lib/chainlink
+	url = https://github.com/smartcontractkit/chainlink


### PR DESCRIPTION
Unable to update this submodule in the core protocol repo, probably related to this. Not sure how the initial url was setup weirdly to `https://github.com/lib/chainlink` 🤷‍♂️ 